### PR TITLE
Fix case in PHPUnit_Framework_TestCase reference (presumably loader issue)

### DIFF
--- a/tests/Hamcrest/AbstractMatcherTest.php
+++ b/tests/Hamcrest/AbstractMatcherTest.php
@@ -4,7 +4,7 @@ namespace Hamcrest;
 class UnknownType {
 }
 
-abstract class AbstractMatcherTest extends \PhpUnit_Framework_TestCase
+abstract class AbstractMatcherTest extends \PHPUnit_Framework_TestCase
 {
 
     const ARGUMENT_IGNORED = "ignored";


### PR DESCRIPTION
Running phpunit against the tests throws class loading exception as PHPUnit is spelled PhpUnit in AbstractMatcherTest extends. Seems a weird one - probably composer.