### PR TITLE
Add phpunit to composer.json as require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 	},
 
 	"require-dev": {
+		"phpunit/phpunit": "~4.4",
 		"satooshi/php-coveralls": "dev-master",
 		"phpunit/php-file-iterator": "1.3.3"
 	},


### PR DESCRIPTION
Set to version 4.4 or greater and no issues noted. This allows tests to be run using vendor/bin/phpunit "../vendor/bin/phpunit" from ./tests.