### PR TITLE
Load non-namespaced functions only if previously unloaded

### DIFF
--- a/hamcrest/Hamcrest.php
+++ b/hamcrest/Hamcrest.php
@@ -7,6 +7,10 @@
 // This file is generated from the static method @factory doctags.
 
 /**
+ * Start of conditional function definitions
+ */
+if (!function_exists('equalToIgnoringWhiteSpace')):
+/**
  * Make an assertion and throw {@link Hamcrest_AssertionError} if it fails.
  *
  * Example:
@@ -724,3 +728,8 @@ function hasXPath($xpath, $matcher = null)
 {
     return \Hamcrest\Xml\HasXPath::hasXPath($xpath, $matcher);
 }
+
+/**
+ * End of conditional function definitions
+ */
+endif;


### PR DESCRIPTION
Checks if one of the more unique functions is previously defined. If not, will try to load all of the functions. This should help with hamcrest loading cross-project boundaries. Won't check all functions so clashes can still occur with non-hamcrest code (which is likely okay to leave alone).