### PR TITLE
Don't load global functions by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
 script:
   - mkdir -p build/logs
-  - php vendor/bin/phpunit --coverage-clover=build/logs/clover.xml tests
+  - php vendor/bin/phpunit --coverage-clover=build/logs/clover.xml -c tests/phpunit.xml.dist
 
 after_script:
   - php vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
 	],
 
 	"autoload": {
-		"classmap": ["hamcrest"],
-		"files": ["hamcrest/Hamcrest.php"]
+		"classmap": ["hamcrest"]
 	},
 	"autoload-dev": {
 		"classmap": ["tests", "generator"]

--- a/hamcrest/Hamcrest/Util.php
+++ b/hamcrest/Hamcrest/Util.php
@@ -12,6 +12,10 @@ namespace Hamcrest;
  */
 class Util
 {
+    public static function registerGlobalFunctions()
+    {
+        require_once __DIR__.'/../Hamcrest.php';
+    }
 
     /**
      * Wraps the item with an IsEqual matcher if it isn't a matcher already.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,18 +1,11 @@
 <?php
+
 error_reporting(E_ALL | E_STRICT);
+
 require __DIR__ . '/../vendor/autoload.php';
 
 if (defined('E_DEPRECATED')) {
     error_reporting(error_reporting() | E_DEPRECATED);
 }
 
-define('HAMCREST_TEST_BASE', realpath(dirname(__FILE__)));
-define('HAMCREST_BASE', realpath(dirname(dirname(__FILE__))));
-
-set_include_path(implode(PATH_SEPARATOR, array(
-    HAMCREST_TEST_BASE,
-    HAMCREST_BASE . '/hamcrest',
-    get_include_path()
-)));
-
-require_once 'Hamcrest.php';
+Hamcrest\Util::registerGlobalFunctions();


### PR DESCRIPTION
I'd like to propose this, it would mean mockery can keep a dependency on hamcrest and make use of all it's lovely matchers.

The only question for me would be, do we want to bump a major version number?