### PR TITLE
Add branch alias, starting 2.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,11 @@
 		"kodova/hamcrest-php": "*",
 		"davedevelopment/hamcrest-php": "*",
 		"cordoval/hamcrest-php": "*"
-	}
+	},
+
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    }
 }


### PR DESCRIPTION
I've created a 1.2 branch with appropriate alias for any further 1.2 work https://github.com/hamcrest/hamcrest-php/tree/1.2