### PR TITLE
Fix license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "library",
 	"description": "This is the PHP port of Hamcrest Matchers",
 	"keywords": ["test"],
-	"license": "BSD",
+	"license": "BSD-3-Clause",
 	"authors": [
 	],
 


### PR DESCRIPTION
I believe the LICENSE.txt resembles the BSD 3-claus license, and `composer validate` complains about the invalid license identifier "BSD".