### PR TITLE
Added the PHP tutorial to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ Hamcrest matchers are easy to use as:
 ```php
 Hamcrest_MatcherAssert::assertThat('a', Hamcrest_Matchers::equalToIgnoringCase('A'));
 ```
+
+
+Documentation
+-------------
+A tutorial can be found on the [Hamcrest site](https://code.google.com/archive/p/hamcrest/wikis/TutorialPHP.wiki).


### PR DESCRIPTION
I found the PHP tutorial on the Hamcrest site and thought it would be a good idea to link to it in the readme, since it provides a slightly more comprehensive overview of how to use Hamcrest.

It's possible that the tutorial itself could be pulled into the readme, but I don't know how that would affect maintenance, so I've gone for the link approach here.