### PR TITLE
Matchers can now be used as callables

### DIFF
--- a/hamcrest/Hamcrest/BaseMatcher.php
+++ b/hamcrest/Hamcrest/BaseMatcher.php
@@ -22,4 +22,9 @@ abstract class BaseMatcher implements Matcher
     {
         return StringDescription::toString($this);
     }
+
+    public function __invoke()
+    {
+        return call_user_func_array(array($this, 'matches'), func_get_args());
+    }
 }

--- a/tests/Hamcrest/InvokedMatcherTest.php
+++ b/tests/Hamcrest/InvokedMatcherTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Hamcrest;
+
+
+class SampleInvokeMatcher extends BaseMatcherTest
+{
+    private $matchAgainst;
+
+    public function __construct($matchAgainst)
+    {
+        $this->matchAgainst = $matchAgainst;
+    }
+
+    public function matches($item)
+    {
+        return $item == $this->matchAgainst;
+    }
+
+}
+
+class InvokedMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInvokedMatchersCallMatches()
+    {
+        $sampleMatcher = new SampleInvokeMatcher("foo");
+
+        $this->assertEquals(
+            $sampleMatcher("foo"),
+            true
+        );
+    }
+}

--- a/tests/Hamcrest/InvokedMatcherTest.php
+++ b/tests/Hamcrest/InvokedMatcherTest.php
@@ -24,12 +24,7 @@ class InvokedMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $sampleMatcher = new SampleInvokeMatcher('foo');
 
-        $this->assertTrue(
-            $sampleMatcher('foo')
-        );
-
-        $this->assertFalse(
-            $sampleMatcher('bar')
-        );
+        $this->assertTrue($sampleMatcher('foo'));
+        $this->assertFalse($sampleMatcher('bar'));
     }
 }

--- a/tests/Hamcrest/InvokedMatcherTest.php
+++ b/tests/Hamcrest/InvokedMatcherTest.php
@@ -24,9 +24,12 @@ class InvokedMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $sampleMatcher = new SampleInvokeMatcher("foo");
 
-        $this->assertEquals(
-            $sampleMatcher("foo"),
-            true
+        $this->assertTrue(
+            $sampleMatcher("foo")
+        );
+
+        $this->assertFalse(
+            $sampleMatcher("bar")
         );
     }
 }

--- a/tests/Hamcrest/InvokedMatcherTest.php
+++ b/tests/Hamcrest/InvokedMatcherTest.php
@@ -22,14 +22,14 @@ class InvokedMatcherTest extends \PHPUnit_Framework_TestCase
 {
     public function testInvokedMatchersCallMatches()
     {
-        $sampleMatcher = new SampleInvokeMatcher("foo");
+        $sampleMatcher = new SampleInvokeMatcher('foo');
 
         $this->assertTrue(
-            $sampleMatcher("foo")
+            $sampleMatcher('foo')
         );
 
         $this->assertFalse(
-            $sampleMatcher("bar")
+            $sampleMatcher('bar')
         );
     }
 }


### PR DESCRIPTION
I've added the __invoke() magic method to BaseMatcher so that Hamcrest matchers can be used as callables. In this PR, __invoke() calls matches() on the matcher with the arguments given to invoke.

This means that, for example, the sugar-functions can be used with array_filter as follows:

```php
<?php

$foo = array("Hello", "Hello there", "Goodbye");
$bar = array_filter($foo, startsWith("Hello"));
// $bar == ["Hello", "Hello there"]
```

It's not a huge change, and all the tests still pass. However, I wasn't sure where to put a test for the new behaviour, or if you even consider it worth a test?

Thanks for considering the PR.