### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     - php: 5.3
       dist: precise
   allow_failures:
+    - php: nightly
     - php: hhvm
     - php: hhvm-nightly
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require-dev": {
 		"satooshi/php-coveralls": "^1.0",
 		"phpunit/php-file-iterator": "^1.4",
-		"phpunit/phpunit": ">=4.8.35 <5|>=5.4.3 <6"
+		"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
 	},
 
 	"replace": {

--- a/tests/Hamcrest/Core/CombinableMatcherTest.php
+++ b/tests/Hamcrest/Core/CombinableMatcherTest.php
@@ -7,7 +7,7 @@ class CombinableMatcherTest extends \Hamcrest\AbstractMatcherTest
     private $_either_3_or_4;
     private $_not_3_and_not_4;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_either_3_or_4 = \Hamcrest\Core\CombinableMatcher::either(equalTo(3))->orElse(equalTo(4));
         $this->_not_3_and_not_4 = \Hamcrest\Core\CombinableMatcher::both(not(equalTo(3)))->andAlso(not(equalTo(4)));

--- a/tests/Hamcrest/Core/IsInstanceOfTest.php
+++ b/tests/Hamcrest/Core/IsInstanceOfTest.php
@@ -7,7 +7,7 @@ class IsInstanceOfTest extends \Hamcrest\AbstractMatcherTest
     private $_baseClassInstance;
     private $_subClassInstance;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_baseClassInstance = new \Hamcrest\Core\SampleBaseClass('good');
         $this->_subClassInstance = new \Hamcrest\Core\SampleSubClass('good');

--- a/tests/Hamcrest/FeatureMatcherTest.php
+++ b/tests/Hamcrest/FeatureMatcherTest.php
@@ -34,7 +34,7 @@ class FeatureMatcherTest extends \Hamcrest\AbstractMatcherTest
 
     private $_resultMatcher;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_resultMatcher = $this->_resultMatcher();
     }

--- a/tests/Hamcrest/StringDescriptionTest.php
+++ b/tests/Hamcrest/StringDescriptionTest.php
@@ -23,7 +23,7 @@ class StringDescriptionTest extends TestCase
 
     private $_description;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_description = new \Hamcrest\StringDescription();
     }

--- a/tests/Hamcrest/Text/IsEqualIgnoringWhiteSpaceTest.php
+++ b/tests/Hamcrest/Text/IsEqualIgnoringWhiteSpaceTest.php
@@ -6,7 +6,7 @@ class IsEqualIgnoringWhiteSpaceTest extends \Hamcrest\AbstractMatcherTest
 
     private $_matcher;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_matcher = \Hamcrest\Text\IsEqualIgnoringWhiteSpace::equalToIgnoringWhiteSpace(
             "Hello World   how\n are we? "

--- a/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
+++ b/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
@@ -8,7 +8,7 @@ class StringContainsIgnoringCaseTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringContains;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_stringContains = \Hamcrest\Text\StringContainsIgnoringCase::containsStringIgnoringCase(
             strtolower(self::EXCERPT)

--- a/tests/Hamcrest/Text/StringContainsInOrderTest.php
+++ b/tests/Hamcrest/Text/StringContainsInOrderTest.php
@@ -6,7 +6,7 @@ class StringContainsInOrderTest extends \Hamcrest\AbstractMatcherTest
 
     private $_m;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_m = \Hamcrest\Text\StringContainsInOrder::stringContainsInOrder(array('a', 'b', 'c'));
     }

--- a/tests/Hamcrest/Text/StringContainsTest.php
+++ b/tests/Hamcrest/Text/StringContainsTest.php
@@ -8,7 +8,7 @@ class StringContainsTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringContains;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_stringContains = \Hamcrest\Text\StringContains::containsString(self::EXCERPT);
     }

--- a/tests/Hamcrest/Text/StringEndsWithTest.php
+++ b/tests/Hamcrest/Text/StringEndsWithTest.php
@@ -8,7 +8,7 @@ class StringEndsWithTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringEndsWith;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_stringEndsWith = \Hamcrest\Text\StringEndsWith::endsWith(self::EXCERPT);
     }

--- a/tests/Hamcrest/Text/StringStartsWithTest.php
+++ b/tests/Hamcrest/Text/StringStartsWithTest.php
@@ -8,7 +8,7 @@ class StringStartsWithTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringStartsWith;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_stringStartsWith = \Hamcrest\Text\StringStartsWith::startsWith(self::EXCERPT);
     }


### PR DESCRIPTION
# Changed log
- Let `php-nightly`  be allowed to be failure because nobody can guarantee that this nightly version will be successful in every Travis CI build.

- Defining correct `PHPUnit` versions to support different PHP versions.
- According to the [PHPUnit reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `PHPUnit\Framework\TestCase::setUp` is `protected`, not `public`.