### PR TITLE
Fix underscores to namespaces in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Usage
 Hamcrest matchers are easy to use as:
 
 ```php
-Hamcrest_MatcherAssert::assertThat('a', Hamcrest_Matchers::equalToIgnoringCase('A'));
+Hamcrest\MatcherAssert::assertThat('a', Hamcrest\Matchers::equalToIgnoringCase('A'));
 ```
 
 Alternatively, you can use the global proxy-functions:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Usage
 Hamcrest matchers are easy to use as:
 
 ```php
-Hamcrest\MatcherAssert::assertThat('a', Hamcrest\Matchers::equalToIgnoringCase('A'));
+\Hamcrest\MatcherAssert::assertThat('a', \Hamcrest\Matchers::equalToIgnoringCase('A'));
 ```
 
 Alternatively, you can use the global proxy-functions:


### PR DESCRIPTION
A simple fix, but could be confusing for people just coming to the package (like me!)