### PR TITLE
Bumped branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.1-dev"
         }
     }
 }


### PR DESCRIPTION
I noticed #40 was merged, which is a new feature, so the next release will be v2.1.0?

---

Maybe it's time for a v2.1.0 tag soon, too? 🚀