### PR TITLE
Ignore files when exporting package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/tests export-ignore
+/.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.gush.yml export-ignore
+/.travis.yml export-ignore
+/CHANGES.txt export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
This commit is part of a campaign to reduce the amount of data transferred to save global bandwidth and reduce the amount of CO2. See https://github.com/Codeception/Codeception/pull/5527 for more info.

I'm not sure about the `generator` folder. Could this also be excluded or is this needed?