### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /.github export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.coveralls.yml export-ignore
 .gush.yml export-ignore
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+/tests export-ignore
+/.github export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.gush.yml export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
when I use phpunit higher than 7.*, because this package depend phpunit less than 7.x, so alaways report me 

`PHP Fatal error:  Declaration of Hamcrest\Core\CombinableMatcherTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in ...`

so I add .gitattributes file to filter tests directory when I depend this package