### PR TITLE
Stop reporting tests without assert as risky

### DIFF
--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -6,7 +6,8 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         beStrictAboutTestsThatDoNotTestAnything="false">
   <testsuites>
     <testsuite name="hamcrest-php">
       <directory suffix="Test.php">.</directory>


### PR DESCRIPTION
`AbstractMatcherTest->testIsNullSafe()` and `AbstractMatcherTest->testCopesWithUnknownTypes()` execute no assertion by design. Currently there are 195 tests marked as risky due to this. This change will stop reporting all these tests as risky.