### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.coveralls.yml export-ignore
+/.gush.yml export-ignore
+/.travis.yml export-ignore
+/.github export-ignore
+/tests export-ignore
+


### PR DESCRIPTION
Add a .gitattributes file to exclude the tests and ci files from the archive export used by composer.

See: https://www.git-scm.com/docs/gitattributes#_creating_an_archive