### PR TITLE
Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/github export-ignore
+/tests export-ignore
+/.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.gush.yml export-ignore
+/.travis.yml export-ignore


### PR DESCRIPTION
Hello,

This PR add `.gitattributes` with `export-ignore` in order to reduce vendor size

More info here:
https://php.watch/articles/composer-gitattributes#export-ignore