### PR TITLE
Allow installation of PHPUnit 8 in order to test with PHP 8.1 and 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,8 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Install PHP 7 dependencies
+      - name: Install PHP dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
-        if: "matrix.php != '8.0'"
-
-      - name: Install PHP 8 dependencies
-        run: composer update --prefer-dist --no-interaction --no-progress --ignore-platform-reqs
-        if: "matrix.php == '8.0'"
 
       - name: Execute tests
         run: vendor/bin/phpunit -c tests/phpunit.xml.dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     name: PHP ${{ matrix.php }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
+tests/.phpunit.result.cache
 vendor

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 
 	"require-dev": {
 		"phpunit/php-file-iterator": "^1.4 || ^2.0",
-		"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+		"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0"
 	},
 
 	"replace": {

--- a/tests/Hamcrest/Core/CombinableMatcherTest.php
+++ b/tests/Hamcrest/Core/CombinableMatcherTest.php
@@ -7,7 +7,10 @@ class CombinableMatcherTest extends \Hamcrest\AbstractMatcherTest
     private $_either_3_or_4;
     private $_not_3_and_not_4;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_either_3_or_4 = \Hamcrest\Core\CombinableMatcher::either(equalTo(3))->orElse(equalTo(4));
         $this->_not_3_and_not_4 = \Hamcrest\Core\CombinableMatcher::both(not(equalTo(3)))->andAlso(not(equalTo(4)));

--- a/tests/Hamcrest/Core/IsInstanceOfTest.php
+++ b/tests/Hamcrest/Core/IsInstanceOfTest.php
@@ -7,7 +7,10 @@ class IsInstanceOfTest extends \Hamcrest\AbstractMatcherTest
     private $_baseClassInstance;
     private $_subClassInstance;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_baseClassInstance = new \Hamcrest\Core\SampleBaseClass('good');
         $this->_subClassInstance = new \Hamcrest\Core\SampleSubClass('good');

--- a/tests/Hamcrest/Core/SetTest.php
+++ b/tests/Hamcrest/Core/SetTest.php
@@ -7,7 +7,10 @@ class SetTest extends \Hamcrest\AbstractMatcherTest
     public static $_classProperty;
     public $_instanceProperty;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         self::$_classProperty = null;
         unset($this->_instanceProperty);

--- a/tests/Hamcrest/FeatureMatcherTest.php
+++ b/tests/Hamcrest/FeatureMatcherTest.php
@@ -34,7 +34,10 @@ class FeatureMatcherTest extends \Hamcrest\AbstractMatcherTest
 
     private $_resultMatcher;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_resultMatcher = $this->_resultMatcher();
     }

--- a/tests/Hamcrest/MatcherAssertTest.php
+++ b/tests/Hamcrest/MatcherAssertTest.php
@@ -6,7 +6,10 @@ use PHPUnit\Framework\TestCase;
 class MatcherAssertTest extends TestCase
 {
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         \Hamcrest\MatcherAssert::resetCount();
     }

--- a/tests/Hamcrest/StringDescriptionTest.php
+++ b/tests/Hamcrest/StringDescriptionTest.php
@@ -23,7 +23,10 @@ class StringDescriptionTest extends TestCase
 
     private $_description;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_description = new \Hamcrest\StringDescription();
     }

--- a/tests/Hamcrest/Text/IsEqualIgnoringWhiteSpaceTest.php
+++ b/tests/Hamcrest/Text/IsEqualIgnoringWhiteSpaceTest.php
@@ -6,7 +6,10 @@ class IsEqualIgnoringWhiteSpaceTest extends \Hamcrest\AbstractMatcherTest
 
     private $_matcher;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_matcher = \Hamcrest\Text\IsEqualIgnoringWhiteSpace::equalToIgnoringWhiteSpace(
             "Hello World   how\n are we? "

--- a/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
+++ b/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
@@ -8,7 +8,10 @@ class StringContainsIgnoringCaseTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringContains;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_stringContains = \Hamcrest\Text\StringContainsIgnoringCase::containsStringIgnoringCase(
             strtolower(self::EXCERPT)

--- a/tests/Hamcrest/Text/StringContainsInOrderTest.php
+++ b/tests/Hamcrest/Text/StringContainsInOrderTest.php
@@ -6,7 +6,10 @@ class StringContainsInOrderTest extends \Hamcrest\AbstractMatcherTest
 
     private $_m;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_m = \Hamcrest\Text\StringContainsInOrder::stringContainsInOrder(array('a', 'b', 'c'));
     }

--- a/tests/Hamcrest/Text/StringContainsTest.php
+++ b/tests/Hamcrest/Text/StringContainsTest.php
@@ -8,7 +8,10 @@ class StringContainsTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringContains;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_stringContains = \Hamcrest\Text\StringContains::containsString(self::EXCERPT);
     }

--- a/tests/Hamcrest/Text/StringEndsWithTest.php
+++ b/tests/Hamcrest/Text/StringEndsWithTest.php
@@ -8,7 +8,10 @@ class StringEndsWithTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringEndsWith;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_stringEndsWith = \Hamcrest\Text\StringEndsWith::endsWith(self::EXCERPT);
     }

--- a/tests/Hamcrest/Text/StringStartsWithTest.php
+++ b/tests/Hamcrest/Text/StringStartsWithTest.php
@@ -8,7 +8,10 @@ class StringStartsWithTest extends \Hamcrest\AbstractMatcherTest
 
     private $_stringStartsWith;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpTest()
     {
         $this->_stringStartsWith = \Hamcrest\Text\StringStartsWith::startsWith(self::EXCERPT);
     }

--- a/tests/Hamcrest/Xml/HasXPathTest.php
+++ b/tests/Hamcrest/Xml/HasXPathTest.php
@@ -7,7 +7,10 @@ class HasXPathTest extends \Hamcrest\AbstractMatcherTest
     protected static $doc;
     protected static $html;
 
-    public static function setUpBeforeClass()
+    /**
+     * @beforeClass
+     */
+    public static function setUpBeforeClassTest()
     {
         self::$xml = <<<XML
 <?xml version="1.0"?>


### PR DESCRIPTION
This PR allows the installation of PHPUnit 8.

After installation, when executed, it generates warnings and mark some tests as risky though.

Please tell me if you prefer they are fixed with this PR or in a subsequent one.

To be honest I didn't go further because I first wanted to be sure the project is still maintained.