### PR TITLE
fix implicitly nullable via default value null for PHP-8.4

### DIFF
--- a/hamcrest/Hamcrest/Xml/HasXPath.php
+++ b/hamcrest/Hamcrest/Xml/HasXPath.php
@@ -32,7 +32,7 @@ class HasXPath extends DiagnosingMatcher
      */
     private $_matcher;
 
-    public function __construct($xpath, Matcher $matcher = null)
+    public function __construct($xpath, ?Matcher $matcher = null)
     {
         $this->_xpath = $xpath;
         $this->_matcher = $matcher;


### PR DESCRIPTION
use of explicit nullable type for php-8.4 compatibility