### PR TITLE
Solve the risky test warnings in PHPUnit

### DIFF
--- a/tests/Hamcrest/AbstractMatcherTest.php
+++ b/tests/Hamcrest/AbstractMatcherTest.php
@@ -12,6 +12,14 @@ abstract class AbstractMatcherTest extends TestCase
     const ARGUMENT_IGNORED = "ignored";
     const ANY_NON_NULL_ARGUMENT = "notnull";
 
+    /**
+     * @before
+     */
+    protected function setUpTest()
+    {
+        MatcherAssert::resetCount();
+    }
+
     abstract protected function createMatcher();
 
     public function assertMatches(\Hamcrest\Matcher $matcher, $arg, $message)
@@ -46,6 +54,9 @@ abstract class AbstractMatcherTest extends TestCase
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testIsNullSafe()
     {
         //Should not generate any notices
@@ -56,6 +67,9 @@ abstract class AbstractMatcherTest extends TestCase
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCopesWithUnknownTypes()
     {
         //Should not generate any notices
@@ -64,5 +78,13 @@ abstract class AbstractMatcherTest extends TestCase
             new UnknownType(),
             new NullDescription()
         );
+    }
+
+    /**
+     * @after
+     */
+    protected function tearDownTest()
+    {
+        $this->addToAssertionCount(MatcherAssert::getCount());
     }
 }

--- a/tests/Hamcrest/Core/CombinableMatcherTest.php
+++ b/tests/Hamcrest/Core/CombinableMatcherTest.php
@@ -12,6 +12,8 @@ class CombinableMatcherTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_either_3_or_4 = \Hamcrest\Core\CombinableMatcher::either(equalTo(3))->orElse(equalTo(4));
         $this->_not_3_and_not_4 = \Hamcrest\Core\CombinableMatcher::both(not(equalTo(3)))->andAlso(not(equalTo(4)));
     }

--- a/tests/Hamcrest/Core/IsInstanceOfTest.php
+++ b/tests/Hamcrest/Core/IsInstanceOfTest.php
@@ -12,6 +12,8 @@ class IsInstanceOfTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_baseClassInstance = new \Hamcrest\Core\SampleBaseClass('good');
         $this->_subClassInstance = new \Hamcrest\Core\SampleSubClass('good');
     }

--- a/tests/Hamcrest/Core/SetTest.php
+++ b/tests/Hamcrest/Core/SetTest.php
@@ -12,6 +12,8 @@ class SetTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         self::$_classProperty = null;
         unset($this->_instanceProperty);
     }

--- a/tests/Hamcrest/FeatureMatcherTest.php
+++ b/tests/Hamcrest/FeatureMatcherTest.php
@@ -39,6 +39,8 @@ class FeatureMatcherTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_resultMatcher = $this->_resultMatcher();
     }
 

--- a/tests/Hamcrest/Text/IsEqualIgnoringWhiteSpaceTest.php
+++ b/tests/Hamcrest/Text/IsEqualIgnoringWhiteSpaceTest.php
@@ -11,6 +11,8 @@ class IsEqualIgnoringWhiteSpaceTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_matcher = \Hamcrest\Text\IsEqualIgnoringWhiteSpace::equalToIgnoringWhiteSpace(
             "Hello World   how\n are we? "
         );

--- a/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
+++ b/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
@@ -13,6 +13,8 @@ class StringContainsIgnoringCaseTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_stringContains = \Hamcrest\Text\StringContainsIgnoringCase::containsStringIgnoringCase(
             strtolower(self::EXCERPT)
         );

--- a/tests/Hamcrest/Text/StringContainsInOrderTest.php
+++ b/tests/Hamcrest/Text/StringContainsInOrderTest.php
@@ -11,6 +11,8 @@ class StringContainsInOrderTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_m = \Hamcrest\Text\StringContainsInOrder::stringContainsInOrder(array('a', 'b', 'c'));
     }
 

--- a/tests/Hamcrest/Text/StringContainsTest.php
+++ b/tests/Hamcrest/Text/StringContainsTest.php
@@ -13,6 +13,8 @@ class StringContainsTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_stringContains = \Hamcrest\Text\StringContains::containsString(self::EXCERPT);
     }
 

--- a/tests/Hamcrest/Text/StringEndsWithTest.php
+++ b/tests/Hamcrest/Text/StringEndsWithTest.php
@@ -13,6 +13,8 @@ class StringEndsWithTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_stringEndsWith = \Hamcrest\Text\StringEndsWith::endsWith(self::EXCERPT);
     }
 

--- a/tests/Hamcrest/Text/StringStartsWithTest.php
+++ b/tests/Hamcrest/Text/StringStartsWithTest.php
@@ -13,6 +13,8 @@ class StringStartsWithTest extends \Hamcrest\AbstractMatcherTest
      */
     protected function setUpTest()
     {
+        parent::setUpTest();
+
         $this->_stringStartsWith = \Hamcrest\Text\StringStartsWith::startsWith(self::EXCERPT);
     }
 

--- a/tests/Hamcrest/UtilTest.php
+++ b/tests/Hamcrest/UtilTest.php
@@ -20,6 +20,9 @@ class UtilTest extends TestCase
         $this->assertTrue($matcher->matches('foo'));
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCheckAllAreMatchersAcceptsMatchers()
     {
         \Hamcrest\Util::checkAllAreMatchers(array(


### PR DESCRIPTION
Solves the same problem as #72 , but in different way using my own recommendations in that PR:

* create a bridge between Hamcrest and PHPUnit assertion tracking code (now Hamcrest performed assertions are seen by the PHPUnit);
* mark 3 tests, that actually don't perform any assertions using the `@doesNotPerformAssertions` annotation.