### PR TITLE
Add missing test for StringDescription:: toString

### DIFF
--- a/hamcrest/Hamcrest/Description.php
+++ b/hamcrest/Hamcrest/Description.php
@@ -19,7 +19,7 @@ interface Description
      *
      * @param string $text
      *
-     * @return \Hamcrest\Description
+     * @return static
      */
     public function appendText($text);
 
@@ -29,7 +29,7 @@ interface Description
      *
      * @param \Hamcrest\SelfDescribing $value
      *
-     * @return \Hamcrest\Description
+     * @return static
      */
     public function appendDescriptionOf(SelfDescribing $value);
 
@@ -38,7 +38,7 @@ interface Description
      *
      * @param mixed $value
      *
-     * @return \Hamcrest\Description
+     * @return static
      */
     public function appendValue($value);
 
@@ -50,7 +50,7 @@ interface Description
      * @param string $end
      * @param array|\IteratorAggregate|\Iterator $values
      *
-     * @return \Hamcrest\Description
+     * @return static
      */
     public function appendValueList($start, $separator, $end, $values);
 
@@ -64,7 +64,7 @@ interface Description
      * @param array|\\IteratorAggregate|\\Iterator $values
      *   must be instances of {@link Hamcrest\SelfDescribing}
      *
-     * @return \Hamcrest\Description
+     * @return static
      */
     public function appendList($start, $separator, $end, $values);
 }

--- a/tests/Hamcrest/StringDescriptionTest.php
+++ b/tests/Hamcrest/StringDescriptionTest.php
@@ -162,4 +162,10 @@ class StringDescriptionTest extends TestCase
         $this->_description->appendList('@start@', '@sep@ ', '@end@', $items->getIterator());
         $this->assertEquals('@start@foo@sep@ bar@end@', (string) $this->_description);
     }
+
+    public function testToStringAppendsSelfDescribing()
+    {
+        $description = $this->_description->toString(new \Hamcrest\SampleSelfDescriber('foo'));
+        $this->assertEquals('foo', $description);
+    }
 }


### PR DESCRIPTION
interestingly, the code is totally fine:

https://github.com/hamcrest/JavaHamcrest/blob/master/hamcrest/src/main/java/org/hamcrest/StringDescription.java#L35

This calls toString, but we actually implemented __toString on the class. So casting as `(string)` must be fine.

Anyway, the test might be helpful