### PR TITLE
Add missing php extensions to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
 	},
 
 	"require": {
-		"php": "^7.4|^8.0"
+		"php": "^7.4|^8.0",
+		"ext-ctype": "*",
+		"ext-dom": "*"
 	},
 
 	"require-dev": {


### PR DESCRIPTION
As discussed in #88 

Think this is the right move: users can still ignore the requirements via Composer and tiptoe around the methods using this extensions.

Since phpunit requires ext-dom this is present anyway on most systems.