### PR TITLE
Suggestion for keeping an consistent, automatic code style (with php-cs-fixer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 tests/.phpunit.result.cache
 vendor
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,6 +4,8 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/hamcrest')
     ->in(__DIR__.'/generator')
     ->in(__DIR__.'/tests')
+    ->notPath('Matchers.php')
+    ->notPath('Hamcrest.php')
     ->name('*.php')
 ;
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,36 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/hamcrest')
+    ->in(__DIR__.'/generator')
+    ->in(__DIR__.'/tests')
+    ->name('*.php')
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        // Use PSR-12 as base but disable the cosmetic rules
+        '@PSR12' => true,
+        
+        // namespace should come directly after the opening tag
+        'blank_line_after_opening_tag' => false,
+        'linebreak_after_opening_tag' => true,
+        'blank_lines_before_namespace' => ['min_line_breaks' => 1, 'max_line_breaks' => 1],
+
+        // add semicolons to the last lines of chained calls
+        'multiline_whitespace_before_semicolons' => ['strategy' => 'new_line_for_chained_calls'],
+        'method_chaining_indentation' => true,
+
+        // parentheses on new expressions when there are no arguments
+        'new_with_parentheses' => ['named_class' => true, 'anonymous_class' => true],
+
+        // use consistent naming for boolean, bool, integer, int, etc
+        'phpdoc_scalar' => true,
+
+        // allow a new line after the class opening
+        'no_blank_lines_after_class_opening' => false,
+
+    ])
+    ->setFinder($finder)
+    ->setRiskyAllowed(false)
+;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,17 @@ Feel free to ask any questions and share your experiences in the [Issue tracking
 1. Create your feature addition or a bug fix branch based on __`master`__ branch in your repository's fork.
 2. Make necessary changes, but __don't mix__ code reformatting with code changes on topic.
 3. Add tests for those changes (please look into `tests/` folder for some examples). This is important so we don't break it in a future version unintentionally.
-4. Check your code using "Coding Standard" (see below).
+4. Fix your code style by using the "Coding Standard" (see below).
 5. Commit your code.
 6. Squash your commits by topic to preserve a clean and readable log.
 7. Create Pull Request.
+
+## Coding Standard
+
+To keep a consice coding standard in the repository, run: 
+```bash
+vendor/bin/php-cs-fixer fix
+```
 
 ## Running the Tests
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 
 	"require-dev": {
 		"phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
-		"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+		"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+		"friendsofphp/php-cs-fixer": "^3.75"
 	},
 
 	"replace": {

--- a/generator/FactoryCall.php
+++ b/generator/FactoryCall.php
@@ -11,7 +11,7 @@ class FactoryCall
      *
      * @var string
      */
-    const INDENT = '    ';
+    public const INDENT = '    ';
 
     /**
      * @var FactoryMethod

--- a/generator/FactoryFile.php
+++ b/generator/FactoryFile.php
@@ -11,7 +11,7 @@ abstract class FactoryFile
      *
      * @var string
      */
-    const INDENT = '    ';
+    public const INDENT = '    ';
 
     private $indent;
 

--- a/generator/GlobalFunctionFile.php
+++ b/generator/GlobalFunctionFile.php
@@ -34,8 +34,8 @@ class GlobalFunctionFile extends FactoryFile
     public function generateFactoryCall(FactoryCall $call)
     {
         $code = "if (!function_exists('{$call->getName()}')) {\n";
-        $code.= parent::generateFactoryCall($call);
-        $code.= "}\n";
+        $code .= parent::generateFactoryCall($call);
+        $code .= "}\n";
 
         return $code;
     }

--- a/hamcrest/Hamcrest/Arrays/IsArray.php
+++ b/hamcrest/Hamcrest/Arrays/IsArray.php
@@ -55,13 +55,13 @@ class IsArray extends TypeSafeMatcher
             return;
         } elseif (array_keys($actual) != array_keys($this->_elementMatchers)) {
             $mismatchDescription->appendText('array keys were ')
-                                                    ->appendValueList(
-                                                        $this->descriptionStart(),
-                                                        $this->descriptionSeparator(),
-                                                        $this->descriptionEnd(),
-                                                        array_keys($actual)
-                                                    )
-                                                    ;
+                ->appendValueList(
+                    $this->descriptionStart(),
+                    $this->descriptionSeparator(),
+                    $this->descriptionEnd(),
+                    array_keys($actual)
+                )
+            ;
 
             return;
         }
@@ -70,7 +70,8 @@ class IsArray extends TypeSafeMatcher
         foreach ($this->_elementMatchers as $k => $matcher) {
             if (!$matcher->matches($actual[$k])) {
                 $mismatchDescription->appendText('element ')->appendValue($k)
-                    ->appendText(' was ')->appendValue($actual[$k]);
+                    ->appendText(' was ')->appendValue($actual[$k])
+                ;
 
                 return;
             }

--- a/hamcrest/Hamcrest/Arrays/IsArrayContaining.php
+++ b/hamcrest/Hamcrest/Arrays/IsArrayContaining.php
@@ -43,8 +43,8 @@ class IsArrayContaining extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description
-                 ->appendText('an array containing ')
-                 ->appendDescriptionOf($this->_elementMatcher)
+            ->appendText('an array containing ')
+            ->appendDescriptionOf($this->_elementMatcher)
         ;
     }
 

--- a/hamcrest/Hamcrest/Arrays/IsArrayContainingInAnyOrder.php
+++ b/hamcrest/Hamcrest/Arrays/IsArrayContainingInAnyOrder.php
@@ -41,8 +41,8 @@ class IsArrayContainingInAnyOrder extends TypeSafeDiagnosingMatcher
     public function describeTo(Description $description)
     {
         $description->appendList('[', ', ', ']', $this->_elementMatchers)
-                                ->appendText(' in any order')
-                                ;
+            ->appendText(' in any order')
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Arrays/IsArrayContainingKey.php
+++ b/hamcrest/Hamcrest/Arrays/IsArrayContainingKey.php
@@ -39,8 +39,8 @@ class IsArrayContainingKey extends TypeSafeMatcher
     {
         //Not using appendValueList() so that keys can be shown
         $mismatchDescription->appendText('array was ')
-                                                ->appendText('[')
-                                                ;
+            ->appendText('[')
+        ;
         $loop = false;
         foreach ($array as $key => $value) {
             if ($loop) {
@@ -55,9 +55,9 @@ class IsArrayContainingKey extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description
-                 ->appendText('array with key ')
-                 ->appendDescriptionOf($this->_keyMatcher)
-                 ;
+            ->appendText('array with key ')
+            ->appendDescriptionOf($this->_keyMatcher)
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Arrays/IsArrayContainingKeyValuePair.php
+++ b/hamcrest/Hamcrest/Arrays/IsArrayContainingKeyValuePair.php
@@ -42,8 +42,8 @@ class IsArrayContainingKeyValuePair extends TypeSafeMatcher
     {
         //Not using appendValueList() so that keys can be shown
         $mismatchDescription->appendText('array was ')
-                                                ->appendText('[')
-                                                ;
+            ->appendText('[')
+        ;
         $loop = false;
         foreach ($array as $key => $value) {
             if ($loop) {
@@ -58,11 +58,11 @@ class IsArrayContainingKeyValuePair extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('array containing [')
-                                ->appendDescriptionOf($this->_keyMatcher)
-                                ->appendText(' => ')
-                                ->appendDescriptionOf($this->_valueMatcher)
-                                ->appendText(']')
-                                ;
+            ->appendDescriptionOf($this->_keyMatcher)
+            ->appendText(' => ')
+            ->appendDescriptionOf($this->_valueMatcher)
+            ->appendText(']')
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Arrays/MatchingOnce.php
+++ b/hamcrest/Hamcrest/Arrays/MatchingOnce.php
@@ -31,9 +31,9 @@ class MatchingOnce
         }
 
         $this->_mismatchDescription
-                 ->appendText('No item matches: ')->appendList('', ', ', '', $this->_elementMatchers)
-                 ->appendText(' in ')->appendValueList('[', ', ', ']', $items)
-                 ;
+            ->appendText('No item matches: ')->appendList('', ', ', '', $this->_elementMatchers)
+            ->appendText(' in ')->appendValueList('[', ', ', ']', $items)
+        ;
 
         return false;
     }
@@ -53,7 +53,7 @@ class MatchingOnce
 
     private function _isMatched($item)
     {
-            /** @var $matcher \Hamcrest\Matcher */
+        /** @var $matcher \Hamcrest\Matcher */
         foreach ($this->_elementMatchers as $i => $matcher) {
             if ($matcher->matches($item)) {
                 unset($this->_elementMatchers[$i]);

--- a/hamcrest/Hamcrest/Collection/IsEmptyTraversable.php
+++ b/hamcrest/Hamcrest/Collection/IsEmptyTraversable.php
@@ -49,7 +49,7 @@ class IsEmptyTraversable extends BaseMatcher
     public static function emptyTraversable()
     {
         if (!self::$_INSTANCE) {
-            self::$_INSTANCE = new self;
+            self::$_INSTANCE = new self();
         }
 
         return self::$_INSTANCE;

--- a/hamcrest/Hamcrest/Core/DescribedAs.php
+++ b/hamcrest/Hamcrest/Core/DescribedAs.php
@@ -18,7 +18,7 @@ class DescribedAs extends BaseMatcher
     private $_matcher;
     private $_values;
 
-    const ARG_PATTERN = '/%([0-9]+)/';
+    public const ARG_PATTERN = '/%([0-9]+)/';
 
     public function __construct($descriptionTemplate, Matcher $matcher, array $values)
     {

--- a/hamcrest/Hamcrest/Core/IsCollectionContaining.php
+++ b/hamcrest/Hamcrest/Core/IsCollectionContaining.php
@@ -43,9 +43,9 @@ class IsCollectionContaining extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description
-                ->appendText('a collection containing ')
-                ->appendDescriptionOf($this->_elementMatcher)
-                ;
+            ->appendText('a collection containing ')
+            ->appendDescriptionOf($this->_elementMatcher)
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Core/IsInstanceOf.php
+++ b/hamcrest/Hamcrest/Core/IsInstanceOf.php
@@ -37,7 +37,8 @@ class IsInstanceOf extends DiagnosingMatcher
 
         if (!($item instanceof $this->_theClass)) {
             $mismatchDescription->appendText('[' . get_class($item) . '] ')
-                                                    ->appendValue($item);
+                ->appendValue($item)
+            ;
 
             return false;
         }
@@ -48,8 +49,8 @@ class IsInstanceOf extends DiagnosingMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('an instance of ')
-                                ->appendText($this->_theClass)
-                                ;
+            ->appendText($this->_theClass)
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Core/IsSame.php
+++ b/hamcrest/Hamcrest/Core/IsSame.php
@@ -29,9 +29,9 @@ class IsSame extends BaseMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('sameInstance(')
-                                ->appendValue($this->_object)
-                                ->appendText(')')
-                                ;
+            ->appendValue($this->_object)
+            ->appendText(')')
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Core/IsTypeOf.php
+++ b/hamcrest/Hamcrest/Core/IsTypeOf.php
@@ -42,10 +42,10 @@ class IsTypeOf extends BaseMatcher
             $description->appendText('was null');
         } else {
             $description->appendText('was ')
-                                    ->appendText(self::getTypeDescription(strtolower(gettype($item))))
-                                    ->appendText(' ')
-                                    ->appendValue($item)
-                                    ;
+                ->appendText(self::getTypeDescription(strtolower(gettype($item))))
+                ->appendText(' ')
+                ->appendValue($item)
+            ;
         }
     }
 

--- a/hamcrest/Hamcrest/FeatureMatcher.php
+++ b/hamcrest/Hamcrest/FeatureMatcher.php
@@ -50,7 +50,8 @@ abstract class FeatureMatcher extends TypeSafeDiagnosingMatcher
 
         if (!$this->_subMatcher->matches($featureValue)) {
             $mismatchDescription->appendText($this->_featureName)
-                                                    ->appendText(' was ')->appendValue($featureValue);
+                ->appendText(' was ')->appendValue($featureValue)
+            ;
 
             return false;
         }
@@ -61,7 +62,7 @@ abstract class FeatureMatcher extends TypeSafeDiagnosingMatcher
     final public function describeTo(Description $description)
     {
         $description->appendText($this->_featureDescription)->appendText(' ')
-                                ->appendDescriptionOf($this->_subMatcher)
-                             ;
+            ->appendDescriptionOf($this->_subMatcher)
+        ;
     }
 }

--- a/hamcrest/Hamcrest/Matcher.php
+++ b/hamcrest/Hamcrest/Matcher.php
@@ -28,23 +28,23 @@ interface Matcher extends SelfDescribing
      *
      * @param mixed $item the object against which the matcher is evaluated.
      *
-     * @return boolean <code>true</code> if <var>$item</var> matches,
+     * @return bool <code>true</code> if <var>$item</var> matches,
      *   otherwise <code>false</code>.
      *
      * @see Hamcrest\BaseMatcher
      */
     public function matches($item);
 
-        /**
-         * Generate a description of why the matcher has not accepted the item.
-         * The description will be part of a larger description of why a matching
-         * failed, so it should be concise.
-         * This method assumes that <code>matches($item)</code> is false, but
-         * will not check this.
-         *
-         * @param mixed $item The item that the Matcher has rejected.
-         * @param Description $description
-         * @return
-         */
+    /**
+     * Generate a description of why the matcher has not accepted the item.
+     * The description will be part of a larger description of why a matching
+     * failed, so it should be concise.
+     * This method assumes that <code>matches($item)</code> is false, but
+     * will not check this.
+     *
+     * @param mixed $item The item that the Matcher has rejected.
+     * @param Description $description
+     * @return
+     */
     public function describeMismatch($item, Description $description);
 }

--- a/hamcrest/Hamcrest/MatcherAssert.php
+++ b/hamcrest/Hamcrest/MatcherAssert.php
@@ -107,8 +107,9 @@ class MatcherAssert
                 $description->appendText($identifier . PHP_EOL);
             }
             $description->appendText('Expected: ')
-                                    ->appendDescriptionOf($matcher)
-                                    ->appendText(PHP_EOL . '     but: ');
+                ->appendDescriptionOf($matcher)
+                ->appendText(PHP_EOL . '     but: ')
+            ;
 
             $matcher->describeMismatch($actual, $description);
 

--- a/hamcrest/Hamcrest/Matchers.php
+++ b/hamcrest/Hamcrest/Matchers.php
@@ -5,7 +5,6 @@
  */
 
 // This file is generated from the static method @factory doctags.
-
 namespace Hamcrest;
 
 /**

--- a/hamcrest/Hamcrest/Matchers.php
+++ b/hamcrest/Hamcrest/Matchers.php
@@ -5,6 +5,7 @@
  */
 
 // This file is generated from the static method @factory doctags.
+
 namespace Hamcrest;
 
 /**

--- a/hamcrest/Hamcrest/Number/IsCloseTo.php
+++ b/hamcrest/Hamcrest/Number/IsCloseTo.php
@@ -33,18 +33,18 @@ class IsCloseTo extends TypeSafeMatcher
     protected function describeMismatchSafely($item, Description $mismatchDescription)
     {
         $mismatchDescription->appendValue($item)
-                                                ->appendText(' differed by ')
-                                                ->appendValue($this->_actualDelta($item))
-                                                ;
+            ->appendText(' differed by ')
+            ->appendValue($this->_actualDelta($item))
+        ;
     }
 
     public function describeTo(Description $description)
     {
         $description->appendText('a numeric value within ')
-                                ->appendValue($this->_delta)
-                                ->appendText(' of ')
-                                ->appendValue($this->_value)
-                                ;
+            ->appendValue($this->_delta)
+            ->appendText(' of ')
+            ->appendValue($this->_value)
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Number/OrderingComparison.php
+++ b/hamcrest/Hamcrest/Number/OrderingComparison.php
@@ -37,18 +37,18 @@ class OrderingComparison extends TypeSafeMatcher
             ->appendValue($item)->appendText(' was ')
             ->appendText($this->_comparison($this->_compare($this->_value, $item)))
             ->appendText(' ')->appendValue($this->_value)
-            ;
+        ;
     }
 
     public function describeTo(Description $description)
     {
         $description->appendText('a value ')
             ->appendText($this->_comparison($this->_minCompare))
-            ;
+        ;
         if ($this->_minCompare != $this->_maxCompare) {
             $description->appendText(' or ')
                 ->appendText($this->_comparison($this->_maxCompare))
-                ;
+            ;
         }
         $description->appendText(' ')->appendValue($this->_value);
     }

--- a/hamcrest/Hamcrest/Text/IsEqualIgnoringCase.php
+++ b/hamcrest/Hamcrest/Text/IsEqualIgnoringCase.php
@@ -35,9 +35,9 @@ class IsEqualIgnoringCase extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('equalToIgnoringCase(')
-                                ->appendValue($this->_string)
-                                ->appendText(')')
-                                ;
+            ->appendValue($this->_string)
+            ->appendText(')')
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Text/IsEqualIgnoringWhiteSpace.php
+++ b/hamcrest/Hamcrest/Text/IsEqualIgnoringWhiteSpace.php
@@ -37,9 +37,9 @@ class IsEqualIgnoringWhiteSpace extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('equalToIgnoringWhiteSpace(')
-                                ->appendValue($this->_string)
-                                ->appendText(')')
-                                ;
+            ->appendValue($this->_string)
+            ->appendText(')')
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Text/StringContainsInOrder.php
+++ b/hamcrest/Hamcrest/Text/StringContainsInOrder.php
@@ -43,9 +43,9 @@ class StringContainsInOrder extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('a string containing ')
-                                ->appendValueList('', ', ', '', $this->_substrings)
-                                ->appendText(' in order')
-                                ;
+            ->appendValueList('', ', ', '', $this->_substrings)
+            ->appendText(' in order')
+        ;
     }
 
     /**

--- a/hamcrest/Hamcrest/Text/SubstringMatcher.php
+++ b/hamcrest/Hamcrest/Text/SubstringMatcher.php
@@ -33,10 +33,10 @@ abstract class SubstringMatcher extends TypeSafeMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('a string ')
-                                ->appendText($this->relationship())
-                                ->appendText(' ')
-                                ->appendValue($this->_substring)
-                                ;
+            ->appendText($this->relationship())
+            ->appendText(' ')
+            ->appendValue($this->_substring)
+        ;
     }
 
     abstract protected function evalSubstringOf($string);

--- a/hamcrest/Hamcrest/Type/IsArray.php
+++ b/hamcrest/Hamcrest/Type/IsArray.php
@@ -27,6 +27,6 @@ class IsArray extends IsTypeOf
      */
     public static function arrayValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsBoolean.php
+++ b/hamcrest/Hamcrest/Type/IsBoolean.php
@@ -27,6 +27,6 @@ class IsBoolean extends IsTypeOf
      */
     public static function booleanValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsCallable.php
+++ b/hamcrest/Hamcrest/Type/IsCallable.php
@@ -32,6 +32,6 @@ class IsCallable extends IsTypeOf
      */
     public static function callableValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsDouble.php
+++ b/hamcrest/Hamcrest/Type/IsDouble.php
@@ -29,6 +29,6 @@ class IsDouble extends IsTypeOf
      */
     public static function doubleValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsInteger.php
+++ b/hamcrest/Hamcrest/Type/IsInteger.php
@@ -27,6 +27,6 @@ class IsInteger extends IsTypeOf
      */
     public static function integerValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsNumeric.php
+++ b/hamcrest/Hamcrest/Type/IsNumeric.php
@@ -31,7 +31,7 @@ class IsNumeric extends IsTypeOf
      * This check is necessary because PHP 7 doesn't recognize hexadecimal string as numeric anymore.
      *
      * @param mixed $item
-     * @return boolean
+     * @return bool
      */
     private function isHexadecimal($item)
     {
@@ -49,6 +49,6 @@ class IsNumeric extends IsTypeOf
      */
     public static function numericValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsObject.php
+++ b/hamcrest/Hamcrest/Type/IsObject.php
@@ -27,6 +27,6 @@ class IsObject extends IsTypeOf
      */
     public static function objectValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsResource.php
+++ b/hamcrest/Hamcrest/Type/IsResource.php
@@ -27,6 +27,6 @@ class IsResource extends IsTypeOf
      */
     public static function resourceValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsScalar.php
+++ b/hamcrest/Hamcrest/Type/IsScalar.php
@@ -29,6 +29,6 @@ class IsScalar extends IsTypeOf
      */
     public static function scalarValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/Type/IsString.php
+++ b/hamcrest/Hamcrest/Type/IsString.php
@@ -27,6 +27,6 @@ class IsString extends IsTypeOf
      */
     public static function stringValue()
     {
-        return new self;
+        return new self();
     }
 }

--- a/hamcrest/Hamcrest/TypeSafeMatcher.php
+++ b/hamcrest/Hamcrest/TypeSafeMatcher.php
@@ -14,13 +14,13 @@ abstract class TypeSafeMatcher extends BaseMatcher
 {
 
     /* Types that PHP can compare against */
-    const TYPE_ANY = 0;
-    const TYPE_STRING = 1;
-    const TYPE_NUMERIC = 2;
-    const TYPE_ARRAY = 3;
-    const TYPE_OBJECT = 4;
-    const TYPE_RESOURCE = 5;
-    const TYPE_BOOLEAN = 6;
+    public const TYPE_ANY = 0;
+    public const TYPE_STRING = 1;
+    public const TYPE_NUMERIC = 2;
+    public const TYPE_ARRAY = 3;
+    public const TYPE_OBJECT = 4;
+    public const TYPE_RESOURCE = 5;
+    public const TYPE_BOOLEAN = 6;
 
     /**
      * The type that is required for a safe comparison

--- a/hamcrest/Hamcrest/Util.php
+++ b/hamcrest/Hamcrest/Util.php
@@ -27,8 +27,7 @@ class Util
     {
         return ($item instanceof Matcher)
             ? $item
-            : Core\IsEqual::equalTo($item)
-            ;
+            : Core\IsEqual::equalTo($item);
     }
 
     /**

--- a/hamcrest/Hamcrest/Xml/HasXPath.php
+++ b/hamcrest/Hamcrest/Xml/HasXPath.php
@@ -131,7 +131,8 @@ class HasXPath extends DiagnosingMatcher
                 $content[] = $node->textContent;
             }
             $mismatchDescription->appendText('XPath returned ')
-                                                    ->appendValue($content);
+                ->appendValue($content)
+            ;
         }
 
         return false;
@@ -152,7 +153,8 @@ class HasXPath extends DiagnosingMatcher
                 return true;
             }
             $mismatchDescription->appendText('XPath expression result was ')
-                                                    ->appendValue($result);
+                ->appendValue($result)
+            ;
         } else {
             if ($this->_matcher->matches($result)) {
                 return true;
@@ -167,8 +169,9 @@ class HasXPath extends DiagnosingMatcher
     public function describeTo(Description $description)
     {
         $description->appendText('XML or HTML document with XPath "')
-                                ->appendText($this->_xpath)
-                                ->appendText('"');
+            ->appendText($this->_xpath)
+            ->appendText('"')
+        ;
         if ($this->_matcher !== null) {
             $description->appendText(' ');
             $this->_matcher->describeTo($description);

--- a/tests/Hamcrest/AbstractMatcherTest.php
+++ b/tests/Hamcrest/AbstractMatcherTest.php
@@ -3,14 +3,15 @@ namespace Hamcrest;
 
 use PHPUnit\Framework\TestCase;
 
-class UnknownType {
+class UnknownType
+{
 }
 
 abstract class AbstractMatcherTest extends TestCase
 {
 
-    const ARGUMENT_IGNORED = "ignored";
-    const ANY_NON_NULL_ARGUMENT = "notnull";
+    public const ARGUMENT_IGNORED = "ignored";
+    public const ANY_NON_NULL_ARGUMENT = "notnull";
 
     abstract protected function createMatcher();
 

--- a/tests/Hamcrest/Array/IsArrayContainingKeyTest.php
+++ b/tests/Hamcrest/Array/IsArrayContainingKeyTest.php
@@ -13,14 +13,14 @@ class IsArrayContainingKeyTest extends AbstractMatcherTest
 
     public function testMatchesSingleElementArrayContainingKey()
     {
-        $array = array('a'=>1);
+        $array = array('a' => 1);
 
         $this->assertMatches(hasKey('a'), $array, 'Matches single key');
     }
 
     public function testMatchesArrayContainingKey()
     {
-        $array = array('a'=>1, 'b'=>2, 'c'=>3);
+        $array = array('a' => 1, 'b' => 2, 'c' => 3);
 
         $this->assertMatches(hasKey('a'), $array, 'Matches a');
         $this->assertMatches(hasKey('c'), $array, 'Matches c');
@@ -28,14 +28,14 @@ class IsArrayContainingKeyTest extends AbstractMatcherTest
 
     public function testMatchesArrayContainingKeyWithIntegerKeys()
     {
-        $array = array(1=>'A', 2=>'B');
+        $array = array(1 => 'A', 2 => 'B');
 
         assertThat($array, hasKey(1));
     }
 
     public function testMatchesArrayContainingKeyWithNumberKeys()
     {
-        $array = array(1=>'A', 2=>'B');
+        $array = array(1 => 'A', 2 => 'B');
 
         assertThat($array, hasKey(1));
 
@@ -55,7 +55,7 @@ class IsArrayContainingKeyTest extends AbstractMatcherTest
 
     public function testDoesNotMatchArrayMissingKey()
     {
-        $array = array('a'=>1, 'b'=>2, 'c'=>3);
+        $array = array('a' => 1, 'b' => 2, 'c' => 3);
 
         $this->assertMismatchDescription('array was ["a" => <1>, "b" => <2>, "c" => <3>]', hasKey('d'), $array);
     }

--- a/tests/Hamcrest/Array/IsArrayContainingKeyValuePairTest.php
+++ b/tests/Hamcrest/Array/IsArrayContainingKeyValuePairTest.php
@@ -13,7 +13,7 @@ class IsArrayContainingKeyValuePairTest extends AbstractMatcherTest
 
     public function testMatchesArrayContainingMatchingKeyAndValue()
     {
-        $array = array('a'=>1, 'b'=>2);
+        $array = array('a' => 1, 'b' => 2);
 
         $this->assertMatches(hasKeyValuePair(equalTo('a'), equalTo(1)), $array, 'matcherA');
         $this->assertMatches(hasKeyValuePair(equalTo('b'), equalTo(2)), $array, 'matcherB');

--- a/tests/Hamcrest/Array/IsArrayTest.php
+++ b/tests/Hamcrest/Array/IsArrayTest.php
@@ -72,8 +72,8 @@ class IsArrayTest extends AbstractMatcherTest
     public function testSupportsMatchesAssociativeArrays()
     {
         $this->assertMatches(
-            anArray(array('x'=>equalTo('a'), 'y'=>equalTo('b'), 'z'=>equalTo('c'))),
-            array('x'=>'a', 'y'=>'b', 'z'=>'c'),
+            anArray(array('x' => equalTo('a'), 'y' => equalTo('b'), 'z' => equalTo('c'))),
+            array('x' => 'a', 'y' => 'b', 'z' => 'c'),
             'should match associative array with matching elements'
         );
     }
@@ -81,8 +81,8 @@ class IsArrayTest extends AbstractMatcherTest
     public function testDoesNotMatchAnAssociativeArrayWhenKeysDoNotMatch()
     {
         $this->assertDoesNotMatch(
-            anArray(array('x'=>equalTo('a'), 'y'=>equalTo('b'))),
-            array('x'=>'b', 'z'=>'c'),
+            anArray(array('x' => equalTo('a'), 'y' => equalTo('b'))),
+            array('x' => 'b', 'z' => 'c'),
             'should not match array with different keys'
         );
     }

--- a/tests/Hamcrest/StringDescriptionTest.php
+++ b/tests/Hamcrest/StringDescriptionTest.php
@@ -130,7 +130,7 @@ class StringDescriptionTest extends TestCase
         $this->_description
             ->appendDescriptionOf(new \Hamcrest\SampleSelfDescriber('foo'))
             ->appendDescriptionOf(new \Hamcrest\SampleSelfDescriber('bar'))
-            ;
+        ;
         $this->assertEquals('foobar', (string) $this->_description);
     }
 

--- a/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
+++ b/tests/Hamcrest/Text/StringContainsIgnoringCaseTest.php
@@ -4,7 +4,7 @@ namespace Hamcrest\Text;
 class StringContainsIgnoringCaseTest extends \Hamcrest\AbstractMatcherTest
 {
 
-    const EXCERPT = 'ExcErPt';
+    public const EXCERPT = 'ExcErPt';
 
     private $_stringContains;
 

--- a/tests/Hamcrest/Text/StringContainsTest.php
+++ b/tests/Hamcrest/Text/StringContainsTest.php
@@ -4,7 +4,7 @@ namespace Hamcrest\Text;
 class StringContainsTest extends \Hamcrest\AbstractMatcherTest
 {
 
-    const EXCERPT = 'EXCERPT';
+    public const EXCERPT = 'EXCERPT';
 
     private $_stringContains;
 

--- a/tests/Hamcrest/Text/StringEndsWithTest.php
+++ b/tests/Hamcrest/Text/StringEndsWithTest.php
@@ -4,7 +4,7 @@ namespace Hamcrest\Text;
 class StringEndsWithTest extends \Hamcrest\AbstractMatcherTest
 {
 
-    const EXCERPT = 'EXCERPT';
+    public const EXCERPT = 'EXCERPT';
 
     private $_stringEndsWith;
 

--- a/tests/Hamcrest/Text/StringStartsWithTest.php
+++ b/tests/Hamcrest/Text/StringStartsWithTest.php
@@ -4,7 +4,7 @@ namespace Hamcrest\Text;
 class StringStartsWithTest extends \Hamcrest\AbstractMatcherTest
 {
 
-    const EXCERPT = 'EXCERPT';
+    public const EXCERPT = 'EXCERPT';
 
     private $_stringStartsWith;
 

--- a/tests/Hamcrest/Type/IsDoubleTest.php
+++ b/tests/Hamcrest/Type/IsDoubleTest.php
@@ -12,7 +12,7 @@ class IsDoubleTest extends \Hamcrest\AbstractMatcherTest
     public function testEvaluatesToTrueIfArgumentMatchesType()
     {
         assertThat((float) 5.2, floatValue());
-        assertThat((double) 5.3, doubleValue());
+        assertThat((float) 5.3, doubleValue());
     }
 
     public function testEvaluatesToFalseIfArgumentDoesntMatchType()

--- a/tests/Hamcrest/Type/IsObjectTest.php
+++ b/tests/Hamcrest/Type/IsObjectTest.php
@@ -11,7 +11,7 @@ class IsObjectTest extends \Hamcrest\AbstractMatcherTest
 
     public function testEvaluatesToTrueIfArgumentMatchesType()
     {
-        assertThat(new \stdClass, objectValue());
+        assertThat(new \stdClass(), objectValue());
     }
 
     public function testEvaluatesToFalseIfArgumentDoesntMatchType()


### PR DESCRIPTION
I noticed a few comments about Codestyle in PRs.  
To keep maintainer and contributors happy, I'd suggest to automate the codestyle. That way everyone can concentrate on the code(quality) and not on the codestyle.

Of course a code-formatter does not everything 1000% the way one wants. It's just not customizable entirely.

However this leads to a more consistent codestyle (thats why PSR-x was born) throughout different projects - which I think is a good thing.

Used: 
https://cs.symfony.com/doc/usage.html

Cause I feel like this has become a defactor-standard.

Based it on PSR-12, but a lot needs customization.
Non "standard" are in this repo:

- the blank line after the opening class brace
- the location of the namespace
- the indentation from chained method calls (this looks almost broken in places?)

Anyway, this is just a suggestion, happy to adjust whatever you want (and we can).

Would probably add this to the pipeline, because otherwise no one runs this, and WHEN someone runs it and wants to contribute everything would be outdated.

Of course we can disable the method chaining rules and leave it in "free"-mode as is right now.

Hope you like it!