### PR TITLE
Fix HasToString description

### DIFF
--- a/hamcrest/Hamcrest.php
+++ b/hamcrest/Hamcrest.php
@@ -313,7 +313,8 @@ if (!function_exists('everyItem')) {
 
 if (!function_exists('hasToString')) {
     /**
-     * Does array size satisfy a given matcher?
+     * Creates a matcher that matches any examined object whose <code>toString</code> or
+     * <code>__toString()</code> method returns a value equalTo the specified string.
      */
     function hasToString($matcher)
     {

--- a/hamcrest/Hamcrest/Core/HasToString.php
+++ b/hamcrest/Hamcrest/Core/HasToString.php
@@ -10,7 +10,7 @@ use Hamcrest\Matcher;
 use Hamcrest\Util;
 
 /**
- * Matches if array size satisfies a nested matcher.
+ * A Matcher that checks the output of the <code>toString()</code> or <code>__toString()</code> method.
  */
 class HasToString extends FeatureMatcher
 {
@@ -45,7 +45,8 @@ class HasToString extends FeatureMatcher
     }
 
     /**
-     * Does array size satisfy a given matcher?
+     * Creates a matcher that matches any examined object whose <code>toString</code> or
+     * <code>__toString()</code> method returns a value equalTo the specified string.
      *
      * @factory
      */

--- a/hamcrest/Hamcrest/Matchers.php
+++ b/hamcrest/Hamcrest/Matchers.php
@@ -248,7 +248,8 @@ class Matchers
     }
 
     /**
-     * Does array size satisfy a given matcher?
+     * Creates a matcher that matches any examined object whose <code>toString</code> or
+     * <code>__toString()</code> method returns a value equalTo the specified string.
      */
     public static function hasToString($matcher)
     {


### PR DESCRIPTION
seems to have been copied from another class

took description from: https://hamcrest.org/JavaHamcrest/javadoc/1.3/org/hamcrest/object/HasToString.html#:~:text=.String%3E%20toStringMatcher)-,Creates%20a%20matcher%20that%20matches%20any%20examined%20object%20whose%20toString,that%20satisfies%20the%20specified%20matcher.