### PR TITLE
Fix PHPStan property.notFound on DOMNameSpaceNode in HasXPath

### DIFF
--- a/hamcrest/Hamcrest/Xml/HasXPath.php
+++ b/hamcrest/Hamcrest/Xml/HasXPath.php
@@ -125,13 +125,15 @@ class HasXPath extends DiagnosingMatcher
             return true;
         } else {
             foreach ($nodes as $node) {
-                if ($this->_matcher->matches($node->textContent)) {
+                if ($node instanceof \DOMNode && $this->_matcher->matches($node->textContent)) {
                     return true;
                 }
             }
             $content = array();
             foreach ($nodes as $node) {
-                $content[] = $node->textContent;
+                if ($node instanceof \DOMNode) {
+                    $content[] = $node->textContent;
+                }
             }
             $mismatchDescription->appendText('XPath returned ')
                                                     ->appendValue($content);


### PR DESCRIPTION
PHPStan 2.2.x updated its bundled DOM stubs so that iterating a \DOMNodeList now yields DOMNameSpaceNode|DOMNode. DOMNameSpaceNode has no $textContent property, which triggered property.notFound errors at HasXPath::matchesContent() (lines 128 and 134).

Guard the textContent access with an instanceof \DOMNode check so only real DOM nodes are matched/collected.